### PR TITLE
feat: Added ability to change the place of NFC icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.0.0+4
+- Updated Documentation
+- Added new property `placeNfcIconAtTheEnd` to place NFC icon at the opposite side of the Chip
+
+## 1.0.0+3
+
+- Added image in `README.md` file
+
 ## 1.0.0+2
 
 - Updated Documentation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `u_credit_card` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  u_credit_card: ^1.0.0+3
+  u_credit_card: ^1.0.0+4
 ```
 
 Install it:
@@ -80,7 +80,20 @@ CreditCardUi(
 
 This will create a credit card user interface with the cardholder's name, card number, validity dates, and blue gradient colors. The card will not have the NFC icon.
 
+If you want to place the NFC icon on the opposite side of the chip please enable it by passing `placeNfcIconAtTheEnd: true`
 
+``` dart
+CreditCardUi(
+    cardHolderFullName: 'John Doe',
+    cardNumber: '1234567812345678',
+    validFrom: '01/23',
+    validThru: '01/28',
+    topLeftColor: Colors.blue,
+    doesSupportNfc: true,
+    placeNfcIconAtTheEnd: true, // <-- NFC icon will be at the end,
+),
+
+```
 
 #### Custom Gradient
 
@@ -93,12 +106,12 @@ CreditCardUi(
   bottomRightColor: Colors.purpleAccent,
 )
 ```
-This will create a credit card user interface with the red to yellow gradient.
+This will create a credit card user interface with a red-to-yellow gradient.
 
 If you want to scale the card, use `scale:` property.
 
-If you set less than 1, card size will be reduced,
-if you set greater than 1, card size will be increased.
+If you set less than 1, the card size will be reduced,
+if you set greater than 1, the card size will be increased.
 
 
 ``` dart
@@ -116,7 +129,7 @@ CreditCardUi(
 ## Contributor
 
 <a href="https://www.linkedin.com/in/utpal-barman/">
-  <img src="https://user-images.githubusercontent.com/16848599/232288339-ecbd6cb1-3210-4304-b1e1-bc8434e290a8.png" width="100px" alt="Utpal Barman"     style="border-radius:50%"/> <br /> <b>Utpal Barman</b>
+  <img src="https://user-images.githubusercontent.com/16848599/232288339-ecbd6cb1-3210-4304-b1e1-bc8434e290a8.png" width="100px" alt="Utpal Barman" style="border-radius:50%"/> <br /> <b>Utpal Barman</b>
 </a>
 
 ## License

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,6 +39,7 @@ class MyHomePage extends StatelessWidget {
           validThru: '01/28',
           topLeftColor: Colors.blue,
           doesSupportNfc: true,
+          placeNfcIconAtTheEnd: true,
         ),
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+2
+version: 1.0.0+1
 
 environment:
   sdk: '>=2.19.6 <3.0.0'

--- a/lib/src/u_credit_card.dart
+++ b/lib/src/u_credit_card.dart
@@ -19,6 +19,7 @@ class CreditCardUi extends StatelessWidget {
     this.bottomRightColor,
     this.doesSupportNfc = true,
     this.scale = 1.0,
+    this.placeNfcIconAtTheEnd = false,
   }) : assert(
           cardNumber.length >= 4,
           'Card no. must be at least 4 of length, found  ${cardNumber.length}',
@@ -57,6 +58,14 @@ class CreditCardUi extends StatelessWidget {
   ///
   /// By default it is `true`
   final bool doesSupportNfc;
+
+  /// Places NFC icon at the opposite side of the chip,
+  ///
+  /// For this value to be impacted,
+  /// card must have NFC cababilities and you must set `doesSupportNfc: true`.
+  /// By default `placeNfcIconAtTheEnd : false`,
+  /// so, icon will be beside the chip if nfc is enabled.
+  final bool placeNfcIconAtTheEnd;
 
   /// Can scale the credit card
   ///
@@ -112,6 +121,7 @@ class CreditCardUi extends StatelessWidget {
                   top: 64,
                   child: CreditCardChipNfcView(
                     doesSupportNfc: doesSupportNfc,
+                    placeNfcIconAtTheEnd: placeNfcIconAtTheEnd,
                   ),
                 ),
                 Positioned(
@@ -150,7 +160,9 @@ class CreditCardUi extends StatelessWidget {
                 Positioned(
                   top: 108,
                   left: 20,
-                  child: CreditCardText(cardNumberMasked),
+                  child: CreditCardText(
+                    cardNumberMasked,
+                  ),
                 ),
               ],
             ),

--- a/lib/src/ui/credit_card_chip_nfc_view.dart
+++ b/lib/src/ui/credit_card_chip_nfc_view.dart
@@ -8,34 +8,45 @@ class CreditCardChipNfcView extends StatelessWidget {
   const CreditCardChipNfcView({
     super.key,
     required this.doesSupportNfc,
+    required this.placeNfcIconAtTheEnd,
   });
 
   ///
   final bool doesSupportNfc;
 
+  ///
+  final bool placeNfcIconAtTheEnd;
+
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        const SizedBox(
-          height: 26,
-          child: CreditCardAssetImage(
-            assetPath: Assets.chip,
-          ),
-        ),
-        if (!doesSupportNfc)
-          const SizedBox()
-        else ...[
-          const SizedBox(width: 12),
-          const SizedBox(
-            height: 18,
-            width: 25,
-            child: CreditCardAssetImage(
-              assetPath: Assets.nfc,
+    return SizedBox(
+      width: 264,
+      child: Row(
+        children: [
+          ...[
+            const SizedBox(width: 12),
+            const SizedBox(
+              height: 26,
+              child: CreditCardAssetImage(
+                assetPath: Assets.chip,
+              ),
             ),
-          ),
+          ],
+          if (placeNfcIconAtTheEnd) const Spacer(),
+          if (!doesSupportNfc)
+            const SizedBox.shrink()
+          else ...[
+            const SizedBox(width: 12),
+            const SizedBox(
+              height: 18,
+              width: 25,
+              child: CreditCardAssetImage(
+                assetPath: Assets.nfc,
+              ),
+            ),
+          ],
         ],
-      ],
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: u_credit_card
 description: Credit Card UI
-version: 1.0.0+2
+version: 1.0.0+4
 homepage: 'https://github.com/utpal-barman/u-credit-card-flutter'
 
 environment:


### PR DESCRIPTION
### What was done?
- Added ability to customize the position of the NFC icon

If you want to place the NFC icon on the opposite side of the chip please enable it by passing `placeNfcIconAtTheEnd: true`

``` dart
CreditCardUi(
    cardHolderFullName: 'John Doe',
    cardNumber: '1234567812345678',
    validFrom: '01/23',
    validThru: '01/28',
    topLeftColor: Colors.blue,
    doesSupportNfc: true,
    placeNfcIconAtTheEnd: true, // <-- NFC icon will be at the end,
),

```