### PR TITLE
chore(release): bump to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.0] 🚀
+
+### Features
+
+- Added `CreditCardController` for programmatic card flipping — call `controller.flip()`, `flipToFront()`, or `flipToBack()` from anywhere in your widget tree to drive the flip animation without user interaction.
+
 ## [1.5.0] 🚀
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 💳 u_credit_card: ^1.5.0
+# 💳 u_credit_card: ^1.6.0
 
 ## Credit Card UI as Flutter Widget 💎
 
@@ -26,7 +26,7 @@
 
    ```yaml
    dependencies:
-     u_credit_card: ^1.5.0
+     u_credit_card: ^1.6.0
    ```
 
 2. **Install** the package:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: u_credit_card
 description: uCreditCard - Easy to use beautiful Card UI Flutter Package.
-version: 1.5.0
+version: 1.6.0
 homepage: "https://github.com/utpal-barman/u-credit-card-flutter"
 repository: "https://github.com/utpal-barman/u-credit-card-flutter"
 topics:


### PR DESCRIPTION
## Release v1.6.0

Cuts the v1.6.0 release: bumps `pubspec.yaml` to `1.6.0`, prepends a new CHANGELOG entry, and updates the README version pin.

### Highlights

- **New `CreditCardController` for programmatic flipping.** Hosts can now call `controller.flip()`, `flipToFront()`, or `flipToBack()` from anywhere in their widget tree to drive the flip animation without a tap.

### Changelog

See `CHANGELOG.md` for the full v1.6.0 entry.

### Source commits (`v1.5.0..develop`)

- `409c730` feat(#32): Add CreditCardController for programmatic card flipping (#34)
- `8c8cd14` docs: add AGENTS.md and CLAUDE.md for agent context (#35) — internal, omitted from changelog
- `885f222` chore(deps): Bump very_good_analysis from 9.0.0 to 10.2.0 (#36) — dev-only dep, omitted from changelog

### Release checklist

- [ ] CHANGELOG entry reads naturally to a consumer who hasn't seen the commits
- [ ] README version pin (header + install snippet) updated to `^1.6.0`
- [ ] `pubspec.yaml` version matches PR title (`1.6.0`)
- [ ] After merge: tag `v1.6.0` on the merge commit and push

### Post-merge tag commands

```bash
git checkout develop
git pull origin develop
git tag -a v1.6.0 -m "Release v1.6.0"
git push origin v1.6.0
```

cc @utpal-barman