### PR TITLE
chore: migrate default and integration branch to main

### DIFF
--- a/.claude/skills/git-ops/SKILL.md
+++ b/.claude/skills/git-ops/SKILL.md
@@ -81,7 +81,7 @@ This applies to: `git commit`, `git commit --amend`, `git tag -a`, `gh pr create
 
 ### 3. Never use destructive operations without explicit user authorization
 
-- No `git push --force` or `--force-with-lease` to shared branches (`develop`, `main`) unless the user explicitly says "force push develop" (or equivalent) in this session. Note: `develop` is also branch-protected on the remote, so force-push will be rejected by GitHub even if attempted.
+- No `git push --force` or `--force-with-lease` to shared branches (`main`, `develop`) unless the user explicitly says "force push main" (or equivalent) in this session. Note: both `main` and `develop` are branch-protected on the remote, so force-push will be rejected by GitHub even if attempted.
 - No `git reset --hard`, `git checkout -- .`, `git clean -fd`, `git branch -D` over unmerged work.
 - No `--no-verify` to skip hooks.
 - No `git config` changes.
@@ -138,23 +138,24 @@ Note the consistent scoping (`chore(example):` not `chore:`), the imperative sub
 
 ## Branches and pushes
 
+- **Always branch off the latest `origin/main`.** Never off `develop`, never off another feature branch, never off whatever happens to be checked out. Run `git fetch origin main` first, then `git checkout -b <branch> origin/main`. This is non-negotiable for this repo — `main` is the default and integration branch.
 - **Branch naming:** `feat/<short-slug>`, `fix/<short-slug>`, `chore/<short-slug>`, `release/v<X.Y.Z>`, `docs/<short-slug>`. Slug is lowercase, hyphenated, derived from the change ("programmatic-card-flipping", not "programmaticCardFlipping").
 - **Pushing a new branch:** `git push -u origin <branch>` so upstream is set.
-- **Pushing to `develop` directly** is allowed only for `.claude/` tooling commits (see [[skill-files-direct-to-develop]]). Everything else goes through a PR.
-- **Force-push:** only on branches you own (`feat/*`, `fix/*`, `release/*` before merge) and only with `--force-with-lease`, never plain `--force`. Never force-push `develop` or `main` without explicit user authorization in the current session — and even then expect GitHub to reject it on protected branches.
+- **Pushing to `main` directly** is allowed only for `.claude/` tooling commits (see [[skill-files-direct-to-main]]). Everything else goes through a PR.
+- **Force-push:** only on branches you own (`feat/*`, `fix/*`, `release/*` before merge) and only with `--force-with-lease`, never plain `--force`. Never force-push `main` or `develop` without explicit user authorization in the current session — and even then expect GitHub to reject it on protected branches.
 
 ## Tags
 
 - Format: `v<MAJOR>.<MINOR>.<PATCH>` (leading `v`). Examples: `v1.6.0`, `v1.6.1`.
 - Always annotated: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`.
-- Tag the **merge commit on `develop` after the release PR merges**, not the release branch tip. See [[release-package-skill]].
+- Tag the **merge commit on `main` after the release PR merges**, not the release branch tip. See [[release-package-skill]].
 - Push tags individually: `git push origin vX.Y.Z`, not `git push --tags` (which can sweep up old/local tags).
 
 ## Amend, rebase, reword
 
 - **Amend** is fine for the commit you just made *if it hasn't been pushed*. After `git commit --amend`, double-check no co-author trailer was re-introduced (the template can sneak back).
 - **Interactive rebase** is fine on private branches before pushing. Don't use the `-i` flag inside this skill's tooling — it requires a TTY. Instead, build the sequence via `git rebase --onto` or by squashing in the UI.
-- **Reword on a pushed branch** requires force-push-with-lease and is allowed on your own branches. Not on `develop`/`main` (protected).
+- **Reword on a pushed branch** requires force-push-with-lease and is allowed on your own branches. Not on `main`/`develop` (protected).
 
 ## What to do when the user says "commit this"
 
@@ -168,7 +169,7 @@ If the diff spans multiple logical changes (e.g. a `feat` plus an unrelated `cho
 
 ## Failure modes to avoid
 
-- Pushing a co-author trailer to `develop` (the headline reason this skill exists).
+- Pushing a co-author trailer to `main` (the headline reason this skill exists).
 - Squashing a meaningful body into the subject line.
 - Using `chore:` as a catch-all when `fix` / `refactor` / `docs` would be more honest.
 - Letting a pre-commit hook failure cause an `--amend` on the wrong commit. If a hook fails, fix the issue, re-stage, and make a NEW commit.

--- a/.claude/skills/release-package/SKILL.md
+++ b/.claude/skills/release-package/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release-package
-description: Cuts a release of this Flutter package — bumps pubspec.yaml version, rewrites CHANGELOG.md from PR commits since the last tag, refreshes the README version pin, opens a release PR to develop, and prepares the matching git tag. Use whenever the user asks to "release", "cut a release", "ship a version", "bump the version", "publish", "tag a release", or names a target version like "release v1.6.0" — even when they don't say the word "release" explicitly (e.g. "make a 1.6 PR", "we're ready to ship 1.6").
+description: Cuts a release of this Flutter package — bumps pubspec.yaml version, rewrites CHANGELOG.md from PR commits since the last tag, refreshes the README version pin, opens a release PR to main, and prepares the matching git tag. Use whenever the user asks to "release", "cut a release", "ship a version", "bump the version", "publish", "tag a release", or names a target version like "release v1.6.0" — even when they don't say the word "release" explicitly (e.g. "make a 1.6 PR", "we're ready to ship 1.6").
 ---
 
 # release-package
 
-A repeatable release workflow for the `u_credit_card` Flutter package. The skill produces a single release PR against `develop` plus a tag plan; it does **not** push tags or merge anything itself.
+A repeatable release workflow for the `u_credit_card` Flutter package. The skill produces a single release PR against `main` plus a tag plan; it does **not** push tags or merge anything itself.
 
 ## Why this skill exists
 
@@ -24,15 +24,15 @@ Do **not** trigger when the user just asks to view the changelog, list tags, or 
 
 ## Hard rules (read before acting)
 
-1. **Always release from the latest `develop`.** Never from a feature branch, never from `main`. Run `git fetch origin develop` first. The release branch (`release/vX.Y.Z`) must be cut from `origin/develop`, and the PR's base must be `develop`. This is non-negotiable for this repo.
-2. **CHANGELOG range is `lastTag..origin/develop`** — not `..HEAD`. The local branch is irrelevant to what's actually shipping.
+1. **Always release from the latest `main`.** Never from a feature branch, never from `develop`. Run `git fetch origin main` first. The release branch (`release/vX.Y.Z`) must be cut from `origin/main`, and the PR's base must be `main`. This is non-negotiable for this repo.
+2. **CHANGELOG range is `lastTag..origin/main`** — not `..HEAD`. The local branch is irrelevant to what's actually shipping.
 3. **Never push the tag yourself.** Create it locally on the release commit *after* the PR merges, and leave the push as an explicit step the user runs. A premature tag pinned to a not-yet-merged commit is a mess to undo.
 4. **Reviewer is `@utpal-barman`.** Always request review from this GitHub user on the release PR. (They are the repo owner and have asked to sign off on every release.)
 5. **Version scheme is `vMAJOR.FEATURE.MINORFIX`** (semver-shaped, with the user's vocabulary). Use the picker rules below — don't guess.
 
 ## Version picker
 
-Look at the commits in `lastTag..origin/develop` and decide:
+Look at the commits in `lastTag..origin/main` and decide:
 
 | Highest commit type present | Bump |
 |---|---|
@@ -49,17 +49,17 @@ Execute these steps in order. After each step, briefly say what you did before m
 ### 1. Verify state and pick the version
 
 ```bash
-git fetch origin develop --tags
+git fetch origin main --tags
 git describe --tags --abbrev=0           # last tag, e.g. v1.5.0
-git log <lastTag>..origin/develop --pretty=format:"%h %s"
+git log <lastTag>..origin/main --pretty=format:"%h %s"
 ```
 
 Confirm with the user the version you intend to cut if (a) they didn't specify one, or (b) their request conflicts with the picker rule.
 
-### 2. Cut the release branch from develop
+### 2. Cut the release branch from main
 
 ```bash
-git checkout -B release/vX.Y.Z origin/develop
+git checkout -B release/vX.Y.Z origin/main
 ```
 
 Use `-B` (not `-b`) so re-running the skill recovers cleanly if the branch already exists locally.
@@ -106,7 +106,7 @@ Prepend a new section under `# Changelog` (above the previous top entry). Use th
 
 **Example transformation** (from this repo, for v1.6.0):
 
-Raw commits on develop since v1.5.0:
+Raw commits on main since v1.5.0:
 ```
 885f222 chore(deps): Bump very_good_analysis from 9.0.0 to 10.2.0 (#36)
 8c8cd14 docs: add AGENTS.md and CLAUDE.md for agent context (#35)
@@ -144,11 +144,11 @@ git push -u origin release/vX.Y.Z
 
 Use `chore(release): bump to vX.Y.Z` for both the commit and the PR title. The repo's older history uses bare `release: ...` but the PR title lint (`amannn/action-semantic-pull-request`) rejects that — `chore(release):` keeps commit and PR title aligned and passes the check. See [[pr-title-lint]] and [[git-ops-skill]].
 
-Open the PR against `develop` and request review from `utpal-barman`:
+Open the PR against `main` and request review from `utpal-barman`:
 
 ```bash
 gh pr create \
-  --base develop \
+  --base main \
   --head release/vX.Y.Z \
   --title "chore(release): bump to vX.Y.Z" \
   --reviewer utpal-barman \
@@ -182,8 +182,8 @@ Return the PR URL to the user.
 After the PR is open, tell the user the exact commands to run *after* the PR merges:
 
 ```bash
-git checkout develop
-git pull origin develop
+git checkout main
+git pull origin main
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
@@ -195,8 +195,8 @@ Do not run these yourself. Tagging an unmerged commit, or pushing a tag the user
 - **No commits since the last tag.** Refuse and surface this — there's nothing to release. Don't create an empty release PR.
 - **Local branch dirty.** Stash or refuse. Never `git checkout -B` over uncommitted work.
 - **Tag already exists** (local or remote). Stop and ask. The version was probably already cut.
-- **`develop` is behind a feature branch the user thinks is "the release".** Tell them: the work must be merged to `develop` first; releases come from `develop`. Offer to wait or to help open the feature PR first.
-- **Pre-1.0 / hotfix off `main`.** Not supported by this skill yet — fall back to manual and tell the user.
+- **`main` is behind a feature branch the user thinks is "the release".** Tell them: the work must be merged to `main` first; releases come from `main`. Offer to wait or to help open the feature PR first.
+- **Hotfix off an older tag** (patching a shipped version without taking everything on `main`). Not supported by this skill yet — fall back to manual and tell the user.
 
 ## Reviewer vs. assignee
 
@@ -204,4 +204,4 @@ The release PR's reviewer should be `@utpal-barman` — but if the PR author *is
 
 ## What success looks like
 
-A single commit on `release/vX.Y.Z` that touches exactly `pubspec.yaml`, `CHANGELOG.md`, and `README.md`; a PR titled `chore(release): bump to vX.Y.Z` against `develop` with `@utpal-barman` as reviewer (or assignee if self); and a clear next-step instruction for the user to tag after merge. Nothing else changes.
+A single commit on `release/vX.Y.Z` that touches exactly `pubspec.yaml`, `CHANGELOG.md`, and `README.md`; a PR titled `chore(release): bump to vX.Y.Z` against `main` with `@utpal-barman` as reviewer (or assignee if self); and a clear next-step instruction for the user to tag after merge. Nothing else changes.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: PR validation
 on:
   push:
     branches:
-      - develop
       - main
 
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ app.*.map.json
 
 # Test related
 coverage
+
+# Claude Code local config
+.claude/settings.local.json
+.claude/commands/


### PR DESCRIPTION
## Description

`main` has replaced `develop` as the repository's default branch. This PR moves the repo's tooling and conventions to match, so nothing is left pointing at `develop`.

- **`.github/workflows/main.yml`** — PR validation's `push` trigger drops `develop`, leaving `main`. The `pull_request` trigger has no branch filter, so PR runs are unchanged. `publish.yml` already triggered on `main` + `v*` tags and needed no edit.
- **`.claude/skills/release-package`** — releases are now cut from `origin/main`, the CHANGELOG range is `lastTag..origin/main`, the release PR bases on `main`, and the tag lands on `main`'s merge commit. The old "hotfix off `main`" edge case is replaced by "hotfix off an older tag", which is what that case actually meant now that `main` is the integration branch.
- **`.claude/skills/git-ops`** — adds an explicit "always branch off the latest `origin/main`" rule; updates the protected-branch, direct-push, and tagging guidance to name `main` first.
- **`.gitignore`** — ignores `.claude/settings.local.json` (per-machine) and `.claude/commands/` (scratch tooling). The shared skills under `.claude/skills/` remain tracked.

Also done outside this diff, on GitHub itself: default branch switched to `main`, and `main`'s branch protection aligned with `develop`'s. Worth flagging that the pre-existing `main` rule carried `lockBranch: true` and `requiresCommitSignatures: true` — that combination would have blocked every merge into `main`, and both are now off.

## Checklist
- [ ] I have updated the package version number in `pubspec.yaml` and `README.md`.
- [ ] I have updated the `CHANGELOG.md` with a brief description of my changes.
- [ ] I have updated the `README.md` documentation to reflect my changes.
- [ ] I have updated any images in `README.md` that need to be changed.
- [x] My code follows the code style of this project.
- [x] I have run the tests and they all pass locally.

Version, CHANGELOG, and README boxes are intentionally unchecked — this touches only CI config and agent tooling, with no published-package surface to version or document.

## Changelog Entry
- (none — internal tooling and CI only, not user-facing)

## Additional Notes

Two follow-ups this PR deliberately does **not** take:

1. **`develop` still exists and is still protected.** It's now unused as an integration branch and gets no CI on push. Deleting it is a call for you to make.
2. **No required status checks** are configured on `main` (or `develop`) — the protection rule has an empty contexts list, so PR validation is advisory rather than blocking. Say the word if you want `pr_validation` / `spell-check` / `semantic_pull_request` made required.

cc @utpal-barman