### PR TITLE
docs(context): add feature-sliced agent context notes

### DIFF
--- a/.claude/context/README.md
+++ b/.claude/context/README.md
@@ -1,0 +1,31 @@
+# Context
+
+Working notes organised **by feature slice**, not by date. One file per slice, each describing the current state of that area and the decisions behind it.
+
+`AGENTS.md` is the source of truth for **how the package works**. This folder is for **what state a feature is in** — what exists, what was decided and why, what's still open.
+
+## The rule
+
+**When something is added to a feature, update that feature's slice in the same change.** Don't append a new dated entry, and don't create a second file for the follow-up work — edit the slice so it describes the world as it is now. A slice that lags the code is worse than no slice.
+
+That means:
+
+- New capability shipped → move it from *Open* to *What exists now* in its slice.
+- Decision taken or reversed → update *Decisions*, keeping the reasoning.
+- Plan approved and implemented → replace the plan with what actually shipped and a PR link.
+- No slice fits → create one, named for the feature, and add it to the index below.
+
+## Conventions
+
+- Name files for the capability, generically: `typography-customization.md`. A slice outlives the ticket that prompted it.
+- Reference **versions, PRs, and issues** rather than dates — `v1.6.0`, `#39` age better than "last Tuesday".
+- Record what was **verified** vs **inferred**. A later reader can't tell them apart otherwise.
+- Nothing secret. This folder is tracked in git, unlike `.claude/settings.local.json` and `.claude/commands/`.
+
+## Slices
+
+| Slice | Covers |
+| --- | --- |
+| [branching-ci-and-releases.md](branching-ci-and-releases.md) | Branch model (`main` as default/integration), protection rules, CI triggers, release and publish flow |
+| [typography-customization.md](typography-customization.md) | Caller-supplied text styles across the card's text slots — planned, not implemented |
+| [agent-tooling.md](agent-tooling.md) | Skills, the `/implement` command, this folder, what's gitignored under `.claude/` |

--- a/.claude/context/agent-tooling.md
+++ b/.claude/context/agent-tooling.md
@@ -1,0 +1,36 @@
+# Agent tooling
+
+The `.claude/` directory: what's there, what's shared, and what stays local.
+
+## What exists now
+
+**Skills** (`.claude/skills/`, tracked)
+
+- `git-ops` — the single source of truth for commits, branches, pushes, and tags. Conventional Commits always; **never** an AI co-author trailer or "Generated with…" footer; always branch off the latest `origin/main`. Other skills defer to it for message format and trailer policy.
+- `release-package` — the full release flow (cut from `origin/main`, bump, changelog, README pins, PR, tag plan). Never pushes tags or merges.
+
+**Commands** (`.claude/commands/`, **gitignored**)
+
+- `/implement <issue>` — takes a reported issue from triage → plan → expert review → implementation → PR. It **always runs in a worktree** (`EnterWorktree` before touching any file), investigates and reproduces before planning, posts the plan as an issue comment, then runs a six-expert agent panel (`flutter-expert`, `dart-expert`, `pub-expert`, `api-expert`, `oss-expert`, `mit-license-expert`) whose consensus is the gate on implementing. Each expert is read-only and must close with a parseable `VERDICT` / `BLOCKING` / `NON_BLOCKING` block.
+
+**Context** (`.claude/context/`, tracked) — this folder. Feature slices, updated in place whenever something is added to the feature.
+
+**Root files** — `CLAUDE.md` (points at `AGENTS.md`), `AGENTS.md` (the real project context: public API, layout invariants, controller lifecycle, commands, conventions), `.clauderc`.
+
+## Decisions
+
+- **`AGENTS.md` is the source of truth for how the package works**, so guidance stays consistent across every coding agent rather than being Claude-specific. `CLAUDE.md` deliberately just points at it.
+- **Skills are tracked; local config and commands are not.** `.claude/settings.local.json` is per-machine and `.claude/commands/` is scratch tooling, so both are gitignored. The consequence: `/implement` works locally but is not shared or reviewed — tracking `.claude/commands/` (or promoting the command to a skill) is the open call.
+- **The `/implement` panel is the gate, with three mandatory user checkpoints** that stop the run even on a unanimous approve: a breaking public API change, any licensing concern, or new `pubspec.yaml` dependencies. Those are the cases where an autonomous wrong call is expensive to walk back on a published package.
+- **Two revision rounds, then stop and ask.** The command never implements over an unresolved `BLOCKING` verdict.
+- **`/implement` always runs in a worktree.** It writes a reproduction test in Phase 1, before the panel has approved anything, and may abandon the approach entirely if the panel rejects it. In the main checkout that would leave the user's tree dirty with work that may never ship, and block them from using the repo while the panel runs. `EnterWorktree` also branches from `origin/main` by default, which is the base the command requires anyway.
+- **`/implement` never touches `pubspec.yaml` `version:` or `CHANGELOG.md`** — see the release flow slice.
+
+## How the agent team actually works
+
+There is no `CreateTeam` tool in this harness. A team is formed by issuing **multiple `Agent` calls in a single message** (they run concurrently), each given a `name`. `SendMessage` to that name then resumes the agent **with its review context intact** — which is what lets the revision round send a changed plan back to only the dissenting experts, so they judge the delta instead of re-reading everything.
+
+## Open
+
+1. **`/implement` is gitignored.** Start tracking `.claude/commands/` and PR it, or move it to `.claude/skills/implement/SKILL.md` (already tracked), or leave it local-only by design.
+2. **The command is untested end-to-end.** The one open issue was planned but paused before the panel ran, so the review-and-implement phases have never executed.

--- a/.claude/context/branching-ci-and-releases.md
+++ b/.claude/context/branching-ci-and-releases.md
@@ -1,0 +1,46 @@
+# Branching, CI, and releases
+
+How work flows from a branch to a published pub.dev version.
+
+## What exists now
+
+**`main` is the default and integration branch.** It was created from `develop` at `e32ef2a` (identical content) and took over in `#39`. `develop` still exists and is still protected, but is no longer used for integration.
+
+- **All new work branches off the latest `origin/main`** — never off `develop`, another feature branch, or whatever happens to be checked out.
+- Branch names: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `release/vX.Y.Z`.
+- PRs target `main`. Merging is gated on one approving review from the code owner and conversation resolution.
+- `.claude/` tooling commits may go straight to `main`; everything else goes through a PR.
+
+**Protection** — `main` and `develop` carry identical classic rules: 1 required approving review, code-owner review, conversation resolution required, no force-push, no deletion, no required status-check contexts, admins not enforced, signatures not required. Force-push is rejected on both even with `--force-with-lease`, so nothing that lands can be rewritten — only reverted.
+
+**CI**
+
+- `.github/workflows/main.yml` (PR validation) — triggers on push to `main` and on any PR. Jobs: semantic PR title, markdown spell-check, `dart format --line-length 80 --set-exit-if-changed lib test`, `flutter analyze lib test`.
+- `.github/workflows/publish.yml` — publishes to pub.dev via OIDC on push to `main` and on a `v*` tag.
+
+**Releases** are driven by the `release-package` skill: cut `release/vX.Y.Z` from `origin/main`, bump `pubspec.yaml`, rewrite the `CHANGELOG.md` entry by hand, refresh the two README version pins, PR to `main`, then tag `main`'s merge commit after it lands. Tags are never pushed by an agent. Latest release: `v1.6.0`.
+
+## Decisions
+
+- **`main` over `develop`.** A single integration branch that is also the publish trigger removes the develop→main promotion step and the drift it invited.
+- **Version bumps and CHANGELOG belong to the release flow only.** Feature and fix PRs never touch `pubspec.yaml` `version:` or `CHANGELOG.md`, so release content stays reviewable in one diff.
+- **Tag the merge commit, not the release branch tip.** Tagging an unmerged commit on a published package is tedious to undo.
+
+## The trap worth remembering
+
+The pre-existing `main` protection rule arrived with **`lockBranch: true`** (branch read-only) and **`requiresCommitSignatures: true`**, while local commits are unsigned. That combination would have rejected every merge into `main`. Both were turned off during the migration.
+
+If merges into `main` ever start failing, check those two first:
+
+```bash
+gh api graphql -f query='{repository(owner:"utpal-barman",name:"u-credit-card-flutter"){
+  branchProtectionRules(first:10){nodes{pattern lockBranch requiresCommitSignatures}}}}'
+```
+
+`required_signatures` is **not** a field on the REST protection `PUT` payload — it has its own `PUT`/`DELETE` sub-endpoint at `branches/<b>/protection/required_signatures`.
+
+## Open
+
+1. **`develop` still exists**, still protected, no longer integrated into, and now gets **no CI on push** (the workflow only triggers on `main`). Deleting it is the maintainer's call.
+2. **No required status checks** on either branch — the protection rules have an empty contexts list, so PR validation is advisory and merging is gated only on review. Making `pr_validation` / `spell-check` / `semantic_pull_request` required is a small change if wanted.
+3. **Default-branch switches don't retarget open PRs.** None were open during the migration, so nothing was stranded, but a pre-switch PR would still be merging into a dead branch.

--- a/.claude/context/typography-customization.md
+++ b/.claude/context/typography-customization.md
@@ -1,0 +1,67 @@
+# Typography customization
+
+Letting consumers supply their own text styles for the card's text slots.
+
+**Status: planned, not implemented.** Plan drafted and paused before review; nothing posted to the tracker, no branch, no code.
+
+## What exists now
+
+Nothing configurable. All ten text slots hard-code colour, size, weight, and letter spacing. A consumer cannot change even the text colour — which matters, because the card renders white text and the README already warns against light gradient colours for that reason.
+
+`lib/src/ui/credit_card_text.dart` is the shared text widget for four slots. It hard-codes exactly what a caller would most want to change (`color: Colors.white`, `fontFamily: UiConstants.fontFamily`, `package:`) and exposes only `letterSpacing`, `fontSize`, `fontWeight` — all internal, since `lib/src/` is private and `lib/u_credit_card.dart` exports only `src/u_credit_card.dart` and `src/controller/credit_card_controller.dart`.
+
+### The ten text slots
+
+Verified by reading each site.
+
+| # | Slot | Location | Current style |
+|---|---|---|---|
+| 1 | Card number | `u_credit_card.dart:369` | `CreditCardText` defaults: ls 3.2, fs 16, w700 |
+| 2 | Card holder name | `credit_card_holder_name_view.dart:19` | ls 2, fs 12, uppercased, inside `SizedBox(width: 172)` |
+| 3 | Valid-from value | `credit_card_validity_view.dart:58` | ls 2, fs 9 |
+| 4 | Valid-thru value | `credit_card_validity_view.dart:83` | ls 2, fs 9 |
+| 5 | "VALID FROM" label | `credit_card_validity_view.dart:45` | fs 5, height 1.2, `ARGB(255,200,200,200)`, inside `SizedBox(width: 24)` |
+| 6 | "VALID THRU" label | `credit_card_validity_view.dart:73` | same as #5 |
+| 7 | Card type title | `credit_card_top_section_view.dart:82` | `white70`, fs 8, ls 1.5 |
+| 8 | Balance | `credit_card_top_section_view.dart:150` | white, fs 14, bold, inside `SizedBox(width: 100)` |
+| 9 | "TAP TO SEE BALANCE" | `credit_card_top_section_view.dart:172` | `black54`, fs 8, bold |
+| 10 | CVV (back side) | `u_credit_card.dart:424` | **no style at all** — inherits `DefaultTextStyle` |
+
+Slots 1–4 route through `CreditCardText`; 5–10 are inline `Text` widgets. Slot 10 is a pre-existing inconsistency: the CVV is the only text that neither uses OCR-A nor sets a colour.
+
+## The plan
+
+Merge semantics, not replacement: each slot's package default is the base, and a caller-supplied `TextStyle` merges on top via `base.merge(userStyle)`. Overriding only `color` therefore keeps OCR-A and the letter spacing, and a `null` style leaves every existing consumer pixel-identical.
+
+| File | Change |
+|---|---|
+| `lib/src/models/credit_card_text_styles.dart` (new) | Immutable `CreditCardTextStyles` with one nullable `TextStyle` per slot — `cardNumber`, `cardHolderName`, `validityValue`, `validityLabel`, `cardTypeTitle`, `balance`, `tapToSeeBalance`, `cvv` — plus `copyWith`, `==`/`hashCode`. Slots 3–6 share `validityValue`/`validityLabel` rather than getting four fields; a per-side split has no plausible use. |
+| `lib/u_credit_card.dart` | Export the new file. |
+| `lib/src/u_credit_card.dart` | One new parameter `this.textStyles = const CreditCardTextStyles()`, threaded to `CreditCardText`, `CreditCardHolderNameView`, `CreditCardValidityView`, `CreditCardTopLogo`, and the CVV `Text`. |
+| `lib/src/ui/credit_card_text.dart` | Add `TextStyle? style`; build the current style as the base and return `base.merge(style)`. Keep `maxLines: 1` and `overflow: TextOverflow.clip`. |
+| The three view files | Accept and apply their slots. Slots 5, 6 and 9 lose `const` where a style is injected. |
+
+**Public API impact:** additive — one optional parameter with a default, one new exported class. No existing signature changes. Semver **minor**.
+
+**Tests:** new file `test/src/credit_card_text_styles_test.dart` (this repo prefers new files over appending) — defaults unchanged at every slot; merge-not-replace (supplying only `color` on `cardNumber` keeps `fontFamily: 'ocr-a'`, `package: 'u_credit_card'`, ls 3.2, fs 16, w700); each slot reaches its intended widget and no other; `copyWith` and value equality; `validityLabel` affects both labels.
+
+**Docs:** dartdoc on the class and every field (`very_good_analysis` requires public-API docs, and coverage feeds pub points); a README styling section noting that sizes are calibrated for the fixed 300×190 design. No CHANGELOG or version edit — that belongs to the release flow.
+
+## Decisions
+
+- **Merge, not replace.** Replacement would silently drop the packaged OCR-A font whenever a caller set a single property, and would make the change non-additive in practice.
+- **Text only.** The maintainer's stated ambition is "all styling customization" — colours, radii, spacing. Widening this slice to cover that would make the diff too large to review; those get their own slices.
+- **No auto-fitting.** Slots 2, 5, 6 and 8 sit inside fixed `SizedBox`es (172, 24, 24, 100) and `CreditCardText` clips at one line, so a large `fontSize` clips rather than reflows. Auto-shrinking or clamping would fight the calibrated-offset invariant in `AGENTS.md`. Document the constraint instead.
+
+## Open questions
+
+1. **One grouped parameter vs. eight flat ones.** This plan proposes a single `textStyles` object. Flutter's own convention for multi-slot widgets is flat parameters (`ListTile.titleTextStyle`, `subtitleTextStyle`, `leadingAndTrailingTextStyle`) — more discoverable in autocomplete, stays `const`-friendly. The grouped object wins on constructor size: `CreditCardUi` already takes 24 parameters, and "all styling customization" implies more coming, which a container absorbs without further churn. **This is the main call to settle before implementing — reversing it later is breaking.**
+2. **CVV default (slot 10).** Giving the CVV an explicit default style is a *visual* change for existing users, not purely additive. The plan keeps its inherited appearance and only applies a style when the caller supplies one. Fixing the inconsistency deserves its own slice.
+
+## What's inferred, not verified
+
+The reporter's issue body is empty — the request is a title plus a maintainer comment promising broad styling customization. That per-slot control (rather than one style for the whole card) is what's wanted is a reading of intent, not a stated requirement. Worth confirming with the reporter before building.
+
+## Out of scope
+
+Colour/radius/gradient/spacing customization; theme inheritance from `Theme.of(context).textTheme` (changes default appearance, so not additive); per-side validity split; the CVV default fix; auto-fitting text to the fixed card size.


### PR DESCRIPTION
## Description

Adds `.claude/context/` — working notes that outlive a single agent session but don't belong in `AGENTS.md`. `AGENTS.md` stays the source of truth for *how the package works*; these slices record *what state a feature is in*: what exists, which decisions were taken and why, and what's still open.

Organised **one file per capability**, not as a dated log. The stated convention is that a slice is updated in place when its feature changes — no appending dated entries, no second file for follow-up work — since a slice that lags the code is worse than no slice. Slices reference versions/PRs (`v1.6.0`, `#39`) rather than dates, and mark what was verified vs. inferred.

Three slices to start:

- **`branching-ci-and-releases.md`** — `main` as default/integration branch, protection rules, CI triggers, release and publish flow. Includes the `lockBranch`/`requiresCommitSignatures` trap found during the migration, which would have blocked every merge into `main`.
- **`typography-customization.md`** — the drafted plan for caller-supplied text styles: all ten hard-coded text slots catalogued with locations, merge-not-replace semantics, and the two decisions still open (grouped `textStyles` object vs. flat parameters; the CVV's missing default style).
- **`agent-tooling.md`** — the skills, the `/implement` command, this folder, and what's ignored under `.claude/`.

Docs only — no `lib/`, `test/`, or workflow changes.

## Checklist
- [ ] I have updated the package version number in `pubspec.yaml` and `README.md`.
- [ ] I have updated the `CHANGELOG.md` with a brief description of my changes.
- [ ] I have updated the `README.md` documentation to reflect my changes.
- [ ] I have updated any images in `README.md` that need to be changed.
- [x] My code follows the code style of this project.
- [x] I have run the tests and they all pass locally.

Version, CHANGELOG, and README boxes are intentionally unchecked: this adds agent-facing notes under `.claude/` with no published-package surface to version or document.

## Changelog Entry
- (none — agent-facing notes only, not user-facing)

## Additional Notes

These files are tracked, and the spell-check job covers `**/*.md`, so `.claude/context/` is now a CI gate. I could not run cspell locally to pre-verify (`npx` is broken in this environment), so CI is the first real check on the prose. `.claude/commands/` stays gitignored and `useGitignore: true` means the checker skips it — which also means the `/implement` command itself is **not** in this PR.