### PR TITLE
chore: target develop for all PRs, main for publishing

### DIFF
--- a/.claude/context/README.md
+++ b/.claude/context/README.md
@@ -26,6 +26,6 @@ That means:
 
 | Slice | Covers |
 | --- | --- |
-| [branching-ci-and-releases.md](branching-ci-and-releases.md) | Branch model (`main` as default/integration), protection rules, CI triggers, release and publish flow |
+| [branching-ci-and-releases.md](branching-ci-and-releases.md) | Branch model (`develop` integrates, `main` publishes), protection rules, CI triggers, release and publish flow |
 | [typography-customization.md](typography-customization.md) | Caller-supplied text styles across the card's text slots — planned, not implemented |
 | [agent-tooling.md](agent-tooling.md) | Skills, the `/implement` command, this folder, what's gitignored under `.claude/` |

--- a/.claude/context/agent-tooling.md
+++ b/.claude/context/agent-tooling.md
@@ -6,8 +6,8 @@ The `.claude/` directory: what's there, what's shared, and what stays local.
 
 **Skills** (`.claude/skills/`, tracked)
 
-- `git-ops` — the single source of truth for commits, branches, pushes, and tags. Conventional Commits always; **never** an AI co-author trailer or "Generated with…" footer; always branch off the latest `origin/main`. Other skills defer to it for message format and trailer policy.
-- `release-package` — the full release flow (cut from `origin/main`, bump, changelog, README pins, PR, tag plan). Never pushes tags or merges.
+- `git-ops` — the single source of truth for commits, branches, pushes, and tags. Conventional Commits always; **never** an AI co-author trailer or "Generated with…" footer; always branch off the latest `origin/develop` and target PRs at `develop`. Other skills defer to it for message format and trailer policy.
+- `release-package` — the full release flow (cut from `origin/develop`, bump, changelog, README pins, PR, tag plan). Never pushes tags or merges.
 
 **Commands** (`.claude/commands/`, **gitignored**)
 
@@ -23,7 +23,7 @@ The `.claude/` directory: what's there, what's shared, and what stays local.
 - **Skills are tracked; local config and commands are not.** `.claude/settings.local.json` is per-machine and `.claude/commands/` is scratch tooling, so both are gitignored. The consequence: `/implement` works locally but is not shared or reviewed — tracking `.claude/commands/` (or promoting the command to a skill) is the open call.
 - **The `/implement` panel is the gate, with three mandatory user checkpoints** that stop the run even on a unanimous approve: a breaking public API change, any licensing concern, or new `pubspec.yaml` dependencies. Those are the cases where an autonomous wrong call is expensive to walk back on a published package.
 - **Two revision rounds, then stop and ask.** The command never implements over an unresolved `BLOCKING` verdict.
-- **`/implement` always runs in a worktree.** It writes a reproduction test in Phase 1, before the panel has approved anything, and may abandon the approach entirely if the panel rejects it. In the main checkout that would leave the user's tree dirty with work that may never ship, and block them from using the repo while the panel runs. `EnterWorktree` also branches from `origin/main` by default, which is the base the command requires anyway.
+- **`/implement` always runs in a worktree.** It writes a reproduction test in Phase 1, before the panel has approved anything, and may abandon the approach entirely if the panel rejects it. In the main checkout that would leave the user's tree dirty with work that may never ship, and block them from using the repo while the panel runs. `EnterWorktree` branches from the default branch (`main`), which is the wrong base now that PRs target `develop`, so the command re-points the worktree branch at `origin/develop` as its first step.
 - **`/implement` never touches `pubspec.yaml` `version:` or `CHANGELOG.md`** — see the release flow slice.
 
 ## How the agent team actually works

--- a/.claude/context/branching-ci-and-releases.md
+++ b/.claude/context/branching-ci-and-releases.md
@@ -4,33 +4,44 @@ How work flows from a branch to a published pub.dev version.
 
 ## What exists now
 
-**`main` is the default and integration branch.** It was created from `develop` at `e32ef2a` (identical content) and took over in `#39`. `develop` still exists and is still protected, but is no longer used for integration.
+Two long-lived branches with different jobs:
 
-- **All new work branches off the latest `origin/main`** — never off `develop`, another feature branch, or whatever happens to be checked out.
-- Branch names: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `release/vX.Y.Z`.
-- PRs target `main`. Merging is gated on one approving review from the code owner and conversation resolution.
-- `.claude/` tooling commits may go straight to `main`; everything else goes through a PR.
+- **`develop` — the integration branch.** Every PR targets it, and every branch is cut from it. `.claude/` tooling commits may be pushed to it directly; everything else goes through a PR.
+- **`main` — the default and publish branch.** It receives *only* release PRs, and `publish.yml` fires on push to `main` plus a `v*` tag. Never push to it directly.
 
-**Protection** — `main` and `develop` carry identical classic rules: 1 required approving review, code-owner review, conversation resolution required, no force-push, no deletion, no required status-check contexts, admins not enforced, signatures not required. Force-push is rejected on both even with `--force-with-lease`, so nothing that lands can be rewritten — only reverted.
+`main` is the repository default (so it's what visitors and `git clone` land on), but it is not where day-to-day work integrates.
+
+**Branch names:** `feat/…`, `fix/…`, `chore/…`, `docs/…`, `release/vX.Y.Z`.
+
+**Protection** — `develop` and `main` carry identical classic rules: 1 required approving review, code-owner review, conversation resolution required, no force-push, no deletion, no required status-check contexts, admins not enforced, signatures not required. Force-push is rejected on both even with `--force-with-lease`, so nothing that lands can be rewritten — only reverted. Admins can bypass the review requirement with `gh pr merge --admin`.
 
 **CI**
 
-- `.github/workflows/main.yml` (PR validation) — triggers on push to `main` and on any PR. Jobs: semantic PR title, markdown spell-check, `dart format --line-length 80 --set-exit-if-changed lib test`, `flutter analyze lib test`.
+- `.github/workflows/main.yml` (PR validation) — triggers on push to `develop` or `main`, and on any PR. Jobs: semantic PR title, markdown spell-check over `**/*.md`, `dart format --line-length 80 --set-exit-if-changed lib test`, `flutter analyze lib test`.
 - `.github/workflows/publish.yml` — publishes to pub.dev via OIDC on push to `main` and on a `v*` tag.
 
-**Releases** are driven by the `release-package` skill: cut `release/vX.Y.Z` from `origin/main`, bump `pubspec.yaml`, rewrite the `CHANGELOG.md` entry by hand, refresh the two README version pins, PR to `main`, then tag `main`'s merge commit after it lands. Tags are never pushed by an agent. Latest release: `v1.6.0`.
+Spell-check covers **all** tracked markdown with `useGitignore: true`, so `.claude/context/` and `.claude/skills/` are CI gates; `.claude/commands/` is gitignored and therefore skipped. The word list lives in `.github/cspell.json`.
+
+**Releases** (`release-package` skill)
+
+1. Cut `release/vX.Y.Z` from `origin/develop`; CHANGELOG range is `lastTag..origin/develop`.
+2. Bump `pubspec.yaml`, rewrite the `CHANGELOG.md` entry by hand, refresh the two README version pins.
+3. PR to **`main`** — the single documented exception to "all PRs target `develop`", because publishing is triggered from `main`.
+4. After merge, tag `main`'s merge commit and push the tag; that publishes.
+5. **Back-merge `main` → `develop`** so `develop` doesn't sit behind on the version/CHANGELOG/README files.
+
+Tags are never pushed by an agent. Latest release: `v1.6.0`.
 
 ## Decisions
 
-- **`main` over `develop`.** A single integration branch that is also the publish trigger removes the develop→main promotion step and the drift it invited.
+- **`develop` integrates, `main` publishes.** All PRs target `develop`; only release PRs reach `main`. The default branch stays `main` so what visitors see is what ships.
+- **Step 5 is mandatory.** The release PR lands the bump, CHANGELOG, and README pins on `main` only. Skipping the back-merge leaves `develop` — the base for every other PR — permanently behind on those three files, and the next release then computes its CHANGELOG range from a stale base.
 - **Version bumps and CHANGELOG belong to the release flow only.** Feature and fix PRs never touch `pubspec.yaml` `version:` or `CHANGELOG.md`, so release content stays reviewable in one diff.
 - **Tag the merge commit, not the release branch tip.** Tagging an unmerged commit on a published package is tedious to undo.
 
 ## The trap worth remembering
 
-The pre-existing `main` protection rule arrived with **`lockBranch: true`** (branch read-only) and **`requiresCommitSignatures: true`**, while local commits are unsigned. That combination would have rejected every merge into `main`. Both were turned off during the migration.
-
-If merges into `main` ever start failing, check those two first:
+The `main` protection rule was created with **`lockBranch: true`** (branch read-only) and **`requiresCommitSignatures: true`**, while local commits are unsigned. That combination rejects every merge into `main`. Both are now off, but they matter again the moment `main` starts refusing a release PR.
 
 ```bash
 gh api graphql -f query='{repository(owner:"utpal-barman",name:"u-credit-card-flutter"){
@@ -39,8 +50,12 @@ gh api graphql -f query='{repository(owner:"utpal-barman",name:"u-credit-card-fl
 
 `required_signatures` is **not** a field on the REST protection `PUT` payload — it has its own `PUT`/`DELETE` sub-endpoint at `branches/<b>/protection/required_signatures`.
 
+## History worth knowing
+
+`main` was created from `develop` and briefly became the integration branch too (`#39`, `#40`), before the model settled on the split above. `develop` was fast-forwarded to `main` to remove the resulting gap, so the two are level as of `489351d` — no divergence to reconcile.
+
 ## Open
 
-1. **`develop` still exists**, still protected, no longer integrated into, and now gets **no CI on push** (the workflow only triggers on `main`). Deleting it is the maintainer's call.
-2. **No required status checks** on either branch — the protection rules have an empty contexts list, so PR validation is advisory and merging is gated only on review. Making `pr_validation` / `spell-check` / `semantic_pull_request` required is a small change if wanted.
-3. **Default-branch switches don't retarget open PRs.** None were open during the migration, so nothing was stranded, but a pre-switch PR would still be merging into a dead branch.
+1. **No required status checks** on either branch — the protection rules have an empty contexts list, so PR validation is advisory and merging is gated only on review. Making `pr_validation` / `spell-check` / `semantic_pull_request` required is a small change if wanted.
+2. **Nothing enforces the back-merge.** Step 5 is a documented instruction, not automation. A missed back-merge is silent until the next release looks wrong.
+3. **Default-branch switches don't retarget open PRs.** Relevant if the branch model is ever revisited again.

--- a/.claude/skills/git-ops/SKILL.md
+++ b/.claude/skills/git-ops/SKILL.md
@@ -81,7 +81,7 @@ This applies to: `git commit`, `git commit --amend`, `git tag -a`, `gh pr create
 
 ### 3. Never use destructive operations without explicit user authorization
 
-- No `git push --force` or `--force-with-lease` to shared branches (`main`, `develop`) unless the user explicitly says "force push main" (or equivalent) in this session. Note: both `main` and `develop` are branch-protected on the remote, so force-push will be rejected by GitHub even if attempted.
+- No `git push --force` or `--force-with-lease` to shared branches (`develop`, `main`) unless the user explicitly says "force push develop" (or equivalent) in this session. Note: both `develop` and `main` are branch-protected on the remote, so force-push will be rejected by GitHub even if attempted.
 - No `git reset --hard`, `git checkout -- .`, `git clean -fd`, `git branch -D` over unmerged work.
 - No `--no-verify` to skip hooks.
 - No `git config` changes.
@@ -138,11 +138,12 @@ Note the consistent scoping (`chore(example):` not `chore:`), the imperative sub
 
 ## Branches and pushes
 
-- **Always branch off the latest `origin/main`.** Never off `develop`, never off another feature branch, never off whatever happens to be checked out. Run `git fetch origin main` first, then `git checkout -b <branch> origin/main`. This is non-negotiable for this repo — `main` is the default and integration branch.
+- **Always branch off the latest `origin/develop`, and always open PRs against `develop`.** Never off another feature branch, never off whatever happens to be checked out. Run `git fetch origin develop` first, then `git checkout -b <branch> origin/develop`. This is non-negotiable for this repo — `develop` is the integration branch.
+- **The one exception is a release PR**, which is cut from `develop` but targets `main`, because `publish.yml` fires on push to `main` plus a `v*` tag. See [[release-package-skill]]. Everything that is not a release goes to `develop`.
 - **Branch naming:** `feat/<short-slug>`, `fix/<short-slug>`, `chore/<short-slug>`, `release/v<X.Y.Z>`, `docs/<short-slug>`. Slug is lowercase, hyphenated, derived from the change ("programmatic-card-flipping", not "programmaticCardFlipping").
 - **Pushing a new branch:** `git push -u origin <branch>` so upstream is set.
-- **Pushing to `main` directly** is allowed only for `.claude/` tooling commits (see [[skill-files-direct-to-main]]). Everything else goes through a PR.
-- **Force-push:** only on branches you own (`feat/*`, `fix/*`, `release/*` before merge) and only with `--force-with-lease`, never plain `--force`. Never force-push `main` or `develop` without explicit user authorization in the current session — and even then expect GitHub to reject it on protected branches.
+- **Pushing to `develop` directly** is allowed only for `.claude/` tooling commits (see [[skill-files-direct-to-develop]]). Everything else goes through a PR. Never push directly to `main` — it only receives release PRs.
+- **Force-push:** only on branches you own (`feat/*`, `fix/*`, `release/*` before merge) and only with `--force-with-lease`, never plain `--force`. Never force-push `develop` or `main` without explicit user authorization in the current session — and even then expect GitHub to reject it on protected branches.
 
 ## Tags
 
@@ -155,7 +156,7 @@ Note the consistent scoping (`chore(example):` not `chore:`), the imperative sub
 
 - **Amend** is fine for the commit you just made *if it hasn't been pushed*. After `git commit --amend`, double-check no co-author trailer was re-introduced (the template can sneak back).
 - **Interactive rebase** is fine on private branches before pushing. Don't use the `-i` flag inside this skill's tooling — it requires a TTY. Instead, build the sequence via `git rebase --onto` or by squashing in the UI.
-- **Reword on a pushed branch** requires force-push-with-lease and is allowed on your own branches. Not on `main`/`develop` (protected).
+- **Reword on a pushed branch** requires force-push-with-lease and is allowed on your own branches. Not on `develop`/`main` (protected).
 
 ## What to do when the user says "commit this"
 
@@ -169,7 +170,7 @@ If the diff spans multiple logical changes (e.g. a `feat` plus an unrelated `cho
 
 ## Failure modes to avoid
 
-- Pushing a co-author trailer to `main` (the headline reason this skill exists).
+- Pushing a co-author trailer to `develop` (the headline reason this skill exists).
 - Squashing a meaningful body into the subject line.
 - Using `chore:` as a catch-all when `fix` / `refactor` / `docs` would be more honest.
 - Letting a pre-commit hook failure cause an `--amend` on the wrong commit. If a hook fails, fix the issue, re-stage, and make a NEW commit.

--- a/.claude/skills/release-package/SKILL.md
+++ b/.claude/skills/release-package/SKILL.md
@@ -24,15 +24,15 @@ Do **not** trigger when the user just asks to view the changelog, list tags, or 
 
 ## Hard rules (read before acting)
 
-1. **Always release from the latest `main`.** Never from a feature branch, never from `develop`. Run `git fetch origin main` first. The release branch (`release/vX.Y.Z`) must be cut from `origin/main`, and the PR's base must be `main`. This is non-negotiable for this repo.
-2. **CHANGELOG range is `lastTag..origin/main`** — not `..HEAD`. The local branch is irrelevant to what's actually shipping.
+1. **Always release from the latest `develop`, and target `main`.** Never from a feature branch, never from `main` itself. Run `git fetch origin develop` first. The release branch (`release/vX.Y.Z`) must be cut from `origin/develop`, and the PR's base must be **`main`** — this is the single documented exception to the repo's "all PRs target `develop`" rule, and it exists because `publish.yml` fires on push to `main` plus a `v*` tag. Non-negotiable for this repo. See [[git-ops-skill]].
+2. **CHANGELOG range is `lastTag..origin/develop`** — not `..HEAD`. The local branch is irrelevant to what's actually shipping.
 3. **Never push the tag yourself.** Create it locally on the release commit *after* the PR merges, and leave the push as an explicit step the user runs. A premature tag pinned to a not-yet-merged commit is a mess to undo.
 4. **Reviewer is `@utpal-barman`.** Always request review from this GitHub user on the release PR. (They are the repo owner and have asked to sign off on every release.)
 5. **Version scheme is `vMAJOR.FEATURE.MINORFIX`** (semver-shaped, with the user's vocabulary). Use the picker rules below — don't guess.
 
 ## Version picker
 
-Look at the commits in `lastTag..origin/main` and decide:
+Look at the commits in `lastTag..origin/develop` and decide:
 
 | Highest commit type present | Bump |
 |---|---|
@@ -49,17 +49,17 @@ Execute these steps in order. After each step, briefly say what you did before m
 ### 1. Verify state and pick the version
 
 ```bash
-git fetch origin main --tags
+git fetch origin develop --tags
 git describe --tags --abbrev=0           # last tag, e.g. v1.5.0
-git log <lastTag>..origin/main --pretty=format:"%h %s"
+git log <lastTag>..origin/develop --pretty=format:"%h %s"
 ```
 
 Confirm with the user the version you intend to cut if (a) they didn't specify one, or (b) their request conflicts with the picker rule.
 
-### 2. Cut the release branch from main
+### 2. Cut the release branch from develop
 
 ```bash
-git checkout -B release/vX.Y.Z origin/main
+git checkout -B release/vX.Y.Z origin/develop
 ```
 
 Use `-B` (not `-b`) so re-running the skill recovers cleanly if the branch already exists locally.
@@ -106,7 +106,7 @@ Prepend a new section under `# Changelog` (above the previous top entry). Use th
 
 **Example transformation** (from this repo, for v1.6.0):
 
-Raw commits on main since v1.5.0:
+Raw commits on develop since v1.5.0:
 ```
 885f222 chore(deps): Bump very_good_analysis from 9.0.0 to 10.2.0 (#36)
 8c8cd14 docs: add AGENTS.md and CLAUDE.md for agent context (#35)
@@ -177,26 +177,35 @@ EOF
 
 Return the PR URL to the user.
 
-### 7. Prepare the tag (do not push)
+### 7. Prepare the tag and the back-merge (do not run either)
 
 After the PR is open, tell the user the exact commands to run *after* the PR merges:
 
 ```bash
+# 1. Tag main's merge commit — this is what publishes to pub.dev
 git checkout main
 git pull origin main
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
+
+# 2. Back-merge so develop doesn't drift behind main
+git checkout develop
+git pull origin develop
+git merge --ff-only origin/main   # falls back to a merge commit if develop moved
+git push origin develop
 ```
 
 Do not run these yourself. Tagging an unmerged commit, or pushing a tag the user hasn't agreed to, is the kind of mistake that's tedious to clean up on a published package.
+
+**The back-merge is not optional.** The release PR lands the version bump, CHANGELOG, and README pins on `main` only. Skip step 2 and `develop` — the branch every other PR targets — is permanently behind on those three files, so the next release computes its CHANGELOG range from a stale base.
 
 ## Edge cases
 
 - **No commits since the last tag.** Refuse and surface this — there's nothing to release. Don't create an empty release PR.
 - **Local branch dirty.** Stash or refuse. Never `git checkout -B` over uncommitted work.
 - **Tag already exists** (local or remote). Stop and ask. The version was probably already cut.
-- **`main` is behind a feature branch the user thinks is "the release".** Tell them: the work must be merged to `main` first; releases come from `main`. Offer to wait or to help open the feature PR first.
-- **Hotfix off an older tag** (patching a shipped version without taking everything on `main`). Not supported by this skill yet — fall back to manual and tell the user.
+- **`develop` is behind a feature branch the user thinks is "the release".** Tell them: the work must be merged to `develop` first; releases come from `develop`. Offer to wait or to help open the feature PR first.
+- **Hotfix off an older tag** (patching a shipped version without taking everything on `develop`). Not supported by this skill yet — fall back to manual and tell the user.
 
 ## Reviewer vs. assignee
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: PR validation
 on:
   push:
     branches:
+      - develop
       - main
 
   pull_request:


### PR DESCRIPTION
## Description

Splits the two long-lived branches by job:

- **`develop` — the integration branch.** Every branch is cut from it and every PR targets it.
- **`main` — the default and publish branch.** Receives *only* release PRs; `publish.yml` fires on push to `main` plus a `v*` tag. `main` stays the repository default so visitors and `git clone` land on what actually ships.

Changes:

- **`.github/workflows/main.yml`** — `develop` restored to the push trigger. It gets no CI otherwise, which matters again now that it's where work integrates.
- **`.claude/skills/git-ops`** — branch off the latest `origin/develop` and target PRs at `develop`; direct pushes for `.claude/` tooling go to `develop`, never to `main`. Tagging still happens on `main`'s merge commit.
- **`.claude/skills/release-package`** — release branch cut from `origin/develop`, CHANGELOG range `lastTag..origin/develop`, PR base `main` as the single documented exception, and a new **required back-merge step**.
- **`.claude/context/`** — slices updated in place per the folder's own rule, including the branch-model rewrite and the reason the back-merge isn't optional.

### The back-merge is the part worth reviewing

A release PR lands the version bump, CHANGELOG entry, and README pins on `main` only. Without merging `main` back into `develop`, `develop` — the base for every other PR — sits permanently behind on those three files, and the next release computes its CHANGELOG range from a stale base. The skill now spells the back-merge out as step 5, but **nothing enforces it**; a missed back-merge is silent until a release looks wrong. Flagged as open in the context slice.

## Checklist
- [ ] I have updated the package version number in `pubspec.yaml` and `README.md`.
- [ ] I have updated the `CHANGELOG.md` with a brief description of my changes.
- [ ] I have updated the `README.md` documentation to reflect my changes.
- [ ] I have updated any images in `README.md` that need to be changed.
- [x] My code follows the code style of this project.
- [x] I have run the tests and they all pass locally.

Version, CHANGELOG, and README boxes are intentionally unchecked: this changes CI config and agent tooling, with no published-package surface to version or document.

## Changelog Entry
- (none — CI config and agent tooling only, not user-facing)

## Additional Notes

`develop` was fast-forwarded to `main` before this branch was cut, so the two were level at `489351d` with no divergence to reconcile.

The `/implement` command was also re-pointed at `develop` (its worktree now re-bases onto `origin/develop`, since `EnterWorktree` defaults to the default branch), but `.claude/commands/` is gitignored so that change is **not** in this diff.